### PR TITLE
Support for Ruby 3

### DIFF
--- a/lib/unconstrained/active_record_plugin.rb
+++ b/lib/unconstrained/active_record_plugin.rb
@@ -1,8 +1,8 @@
 module Unconstrained
   module ActiveRecordPlugin
-    def save(*args)
+    def save(**)
       with_constraints_handling :save do
-        super(*args)
+        super
       end
     end
 

--- a/lib/unconstrained/version.rb
+++ b/lib/unconstrained/version.rb
@@ -1,3 +1,3 @@
 module Unconstrained
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 end


### PR DESCRIPTION
The save method takes keyword arguments such as `save(validate: false)`.  Without this change in ruby 3 passing keyword arguments causes an ArgumentError.